### PR TITLE
Remove content from command creation confirmation message

### DIFF
--- a/src/commands/custom-commands/add-custom-command.ts
+++ b/src/commands/custom-commands/add-custom-command.ts
@@ -27,7 +27,7 @@ class AddCustomCommand extends Command {
             await message.channel.send('Failed to create custom command.');
             return;
         }
-        await message.channel.send(`Created custom command ${commandName} with content "${content}".`);
+        await message.channel.send(`:white_check_mark: Created custom command ${commandName} successfully.`);
     }
 
     name(): string {


### PR DESCRIPTION
This allows for longer custom commands without preventing the bot from saving the content.